### PR TITLE
Remove 'colors'.del() from seed/projects

### DIFF
--- a/db/seeds/test/colors.js
+++ b/db/seeds/test/colors.js
@@ -10,7 +10,6 @@ exports.seed = async function(knex) {
     await knex('colors').del();
 
     return knex('colors').insert(hexColors);
-    
   } catch(error) {
     console.log(`Error seeding data: ${error}`)
   }

--- a/db/seeds/test/projects.js
+++ b/db/seeds/test/projects.js
@@ -26,7 +26,6 @@ const createPalette = (knex, palette) => {
 
 exports.seed = async function(knex) {
   try {
-    await knex('colors').del();
     await knex('palettes').del();
     await knex('projects').del();
     // await knex.raw('ALTER SEQUENCE users_id_seq RESTART WITH 1');


### PR DESCRIPTION
### What does this PR do?
This PR fixes and issue where the `seeds/test/projects.js` had `columns.del()`, thus the `colors` table wasn't being seeded.

### Where should the reviewer start?
In `seeds/test/projects.js`, the line to del() the content from `colors` table has been removed. 