### PR TITLE
Endpoint with dustin

### DIFF
--- a/app.js
+++ b/app.js
@@ -172,6 +172,25 @@ app.post('/api/v1/palettes', async (request, response) => {
   } catch (error) {
     response.status(500).json({ error });
   }
+});
+
+app.delete('/api/v1/projects/:id', async (request, response) => {
+  const { id } = request.params;
+
+  try {
+    const project = await database('projects').where('id', id);
+
+    if (!project) {
+      return response.status(404)
+    }
+
+    await database('palettes').where('project_id', id).del();
+    await database('projects').where('id', id).del();
+
+    response.status(204)
+  } catch (error) {
+    response.status(500).json({ error });
+  }
 })
 
 

--- a/app.js
+++ b/app.js
@@ -102,4 +102,30 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
   }
 });
 
+
+app.get('/api/v1/palettes/:id', async (request, response ) => {
+  const { id } = request.params;
+  try {
+    const palette = await database('palettes').where('id', id);
+
+    if (!palette.length) {
+      return res.status(404).json(`No team found with id ${id}`)
+    }
+
+    response.status(200).json({
+      id: palette[0].id,
+      title: palette[0].title,
+      color_1_id: palette[0].color_1_id,
+      color_2_id: palette[0].color_2_id,
+      color_3_id: palette[0].color_3_id,
+      color_4_id: palette[0].color_4_id,
+      color_5_id: palette[0].color_5_id,
+      project_id: palette[0].project_id
+    });
+  } catch (error) {
+    response.status(500).json({ error })
+  }
+});
+
+
 export default app;

--- a/app.js
+++ b/app.js
@@ -102,25 +102,6 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
   }
 });
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 app.get('/api/v1/palettes/:id', async (request, response ) => {
   const { id } = request.params;
   try {

--- a/app.js
+++ b/app.js
@@ -103,6 +103,24 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
 });
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 app.get('/api/v1/palettes/:id', async (request, response ) => {
   const { id } = request.params;
   try {

--- a/app.js
+++ b/app.js
@@ -127,5 +127,26 @@ app.get('/api/v1/palettes/:id', async (request, response ) => {
   }
 });
 
+app.get('/api/v1/palettes', async (request, response) => {
+  try {
+    const palettes = await database('palettes').select();
+    const displayPalettes = palettes.map(palette => ({
+      id: palette.id,
+      title: palette.title,
+      color_1_id: palette.color_1_id,
+      color_2_id: palette.color_2_id,
+      color_3_id: palette.color_3_id,
+      color_4_id: palette.color_4_id,
+      color_5_id: palette.color_5_id,
+      project_id: palette.project_id
+    }));
+
+    response.status(200).json({ palettes: displayPalettes });
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+
+});
+
 
 export default app;

--- a/app.js
+++ b/app.js
@@ -179,14 +179,12 @@ app.delete('/api/v1/projects/:id', async (request, response) => {
   try {
     const project = await database('projects').where('id', id);
 
-    if (!project) {
-      return response.status(404)
+    if (!project.length) {
+      return response.status(404).send({ error: `No project found with submitted id.` })
     }
-
-    await database('palettes').where('project_id', id).del();
     await database('projects').where('id', id).del();
 
-    response.status(204)
+    response.sendStatus(204)
   } catch (error) {
     response.status(500).json({ error });
   }

--- a/app.js
+++ b/app.js
@@ -145,8 +145,34 @@ app.get('/api/v1/palettes', async (request, response) => {
   } catch (error) {
     response.status(500).json({ error });
   }
-
 });
+
+app.post('/api/v1/palettes', async (request, response) => {
+  const palette = request.body;
+
+  for (let requiredParameter of ['title', 'color_1_id', 'color_2_id', 'color_3_id', 'color_4_id', 'color_5_id', 'project_id']) {
+    if (!palette[requiredParameter]) {
+      return response.status(422).send({ error: `Expected format: { title: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, project_id: <Integer> }. You're missing a "${requiredParameter}" property.` });
+    }
+  }
+
+  try {
+    const { title, color_1_id, color_2_id, color_3_id, color_4_id, color_5_id, project_id } = palette;
+    const id = await database('palettes').insert(palette, 'id');
+    response.status(201).json({
+      id: id[0],
+      title: title,
+      color_1_id: color_1_id,
+      color_2_id: color_2_id,
+      color_3_id: color_3_id,
+      color_4_id: color_4_id,
+      color_5_id: color_5_id,
+      project_id: project_id,
+    })
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+})
 
 
 export default app;

--- a/app.js
+++ b/app.js
@@ -109,7 +109,7 @@ app.get('/api/v1/palettes/:id', async (request, response ) => {
     const palette = await database('palettes').where('id', id);
 
     if (!palette.length) {
-      return res.status(404).json(`No team found with id ${id}`)
+      return response.status(404).json({ error: `Could not find a palette with id: ${id}`})
     }
 
     response.status(200).json({

--- a/app.test.js
+++ b/app.test.js
@@ -133,41 +133,6 @@ describe('Server', () => {
     });
   });
 
-
-  
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   describe('GET /api/v1/palettes/:id', () => {
     it('should return a status code of 200 and a single palette object', async () => {
       const expectedPalette = await database('palettes').first();

--- a/app.test.js
+++ b/app.test.js
@@ -134,6 +134,40 @@ describe('Server', () => {
   });
 
 
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   describe('GET /api/v1/palettes/:id', () => {
     it('should return a status code of 200 and a single palette object', async () => {
       const expectedPalette = await database('palettes').first();

--- a/app.test.js
+++ b/app.test.js
@@ -73,7 +73,8 @@ describe('Server', () => {
     });
 
     it('should return a 422 if there are missing properties from the request body', async () => {
-      const newProject = {missingParameter: 'title'};
+      const newProject = {missingProperty: 'title'};
+
       const response = await request(app).post('/api/v1/projects').send(newProject);
 
       expect(response.status).toBe(422);
@@ -217,4 +218,22 @@ describe('Server', () => {
       expect(response.body.error).toBe(`Expected format: { title: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, project_id: <Integer> }. You're missing a "color_1_id" property.`)
     });
   });
+
+  describe('DELETE /api/v1/projects/:id', () => {
+    it('should should delete a project from the db and return a 204 status code', async () => {
+      const project = await database('projects').first();
+      await database('palettes').where('project_id', project.id).del();
+
+      const response = await request(app).delete(`/api/v1/projects/${project.id}`).send(`${project.id}`);
+      // console.log(response.status)
+
+      // const doesExist = await database('projects').where('id', project.id);
+
+      // console.log(response);
+      // console.log(doesExist);
+
+      expect(response.status).toBe(204);
+      // expect(doesExist.length).toEqual(0);
+    });
+  })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -138,6 +138,7 @@ describe('Server', () => {
       const expectedPalette = await database('palettes').first();
         delete expectedPalette.created_at;
         delete expectedPalette.updated_at;
+
       const { id } = expectedPalette;
       const response = await request(app).get(`/api/v1/palettes/${id}`);
       const result = response.body;
@@ -157,5 +158,26 @@ describe('Server', () => {
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidId}`);
     });
-  })
+  });
+
+  describe('GET /api/v1/palettes', () => {
+    it('should return a status code of 200 and an array of palette objects', async () => {
+      const receivedPalettes = await database('palettes').select();
+      const expectedPalettes = receivedPalettes.map(palette => ({
+        id: palette.id,
+        title: palette.title,
+        color_1_id: palette.color_1_id,
+        color_2_id: palette.color_2_id,
+        color_3_id: palette.color_3_id,
+        color_4_id: palette.color_4_id,
+        color_5_id: palette.color_5_id,
+        project_id: palette.project_id
+      }))
+      const response = await request(app).get('/api/v1/palettes');
+      const palettes = response.body;
+
+      expect(response.status).toBe(200);
+      expect(palettes).toEqual({ palettes: expectedPalettes});
+    })
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -180,4 +180,41 @@ describe('Server', () => {
       expect(palettes).toEqual({ palettes: expectedPalettes});
     })
   });
+
+  describe('POST /api/v1/palettes', () => {
+    it('should post a new student to the db with a 201 status code', async () => {
+      const project = await database('projects').first();
+      const newPalette = {
+        title: 'floor',
+        color_1_id: '#fff443',
+        color_2_id: '#fad443',
+        color_3_id: '#fcd443',
+        color_4_id: '#facd43',
+        color_5_id: '#23f443',
+        project_id: project.id,
+      };
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
+      const palettes = await database('palettes').where('id', response.body.id);
+      const palette = palettes[0];
+
+      expect(response.status).toBe(201);
+      expect(palette.title).toEqual(newPalette.title);
+    });
+
+    it('should return a 422 status code if there is a missing property', async () => {
+      const project = await database('projects').first();
+      const newPalette = {
+        title: 'floor',
+        color_2_id: '#fad443',
+        color_3_id: '#fcd443',
+        color_4_id: '#facd43',
+        color_5_id: '#23f443',
+        project_id: project.id, 
+      };
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
+  
+      expect(response.status).toBe(422);
+      expect(response.body.error).toBe(`Expected format: { title: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, project_id: <Integer> }. You're missing a "color_1_id" property.`)
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -132,4 +132,20 @@ describe('Server', () => {
     });
   });
 
+
+  describe('GET /api/v1/palettes/:id', () => {
+    it('should return a status code of 200 and a single palette object', async () => {
+      const expectedPalette = await database('palettes').first();
+        delete expectedPalette.created_at;
+        delete expectedPalette.updated_at;
+      const { id } = expectedPalette;
+      const response = await request(app).get(`/api/v1/palettes/${id}`);
+      const result = response.body;
+        delete result.created_at;
+        delete result.updated_at;
+
+      expect(response.status).toBe(200);
+      expect(result).toEqual(expectedPalette);
+    })
+  })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -87,7 +87,6 @@ describe('Server', () => {
       const newProject = { title: 'Master bedroom' };
       const targetProject = await database('projects').first();
       const { id } = targetProject;
-      console.log(id);
 
       const response = await request(app).patch(`/api/v1/projects/${id}`).send(newProject)
 
@@ -220,19 +219,21 @@ describe('Server', () => {
 
   describe('DELETE /api/v1/projects/:id', () => {
     it('should should delete a project from the db and return a 204 status code', async () => {
-      const project = await database('projects').first();
-      await database('palettes').where('project_id', project.id).del();
+      const expectedProject = await database('projects').first();
+      const { id } = expectedProject;
 
-      const response = await request(app).delete(`/api/v1/projects/${project.id}`).send(`${project.id}`);
-      // console.log(response.status)
-
-      // const doesExist = await database('projects').where('id', project.id);
-
-      // console.log(response);
-      // console.log(doesExist);
+      const response = await request(app).delete(`/api/v1/projects/${id}`).send({ id });
 
       expect(response.status).toBe(204);
-      // expect(doesExist.length).toEqual(0);
     });
+
+    it('should return a 404 not found error is the id param is not found', async () => {
+      const invalidID = -1;
+
+      const response = await request(app).delete(`/api/v1/projects/${invalidID}`).send({ invalidID });
+
+      expect(response.status).toBe(404)
+      expect(response.body.error).toEqual(`No project found with submitted id.`)
+    })
   })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -146,6 +146,16 @@ describe('Server', () => {
 
       expect(response.status).toBe(200);
       expect(result).toEqual(expectedPalette);
-    })
+    });
+
+    it('should return a 404 if the specific palette is not found', async () => {
+      const invalidId = -467;
+  
+
+      const response = await request(app).get(`/api/v1/palettes/${invalidId}`);
+      
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidId}`);
+    });
   })
 });

--- a/db/migrations/20200207115954_delete_project_id.js
+++ b/db/migrations/20200207115954_delete_project_id.js
@@ -1,0 +1,16 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.dropColumn('project_id');
+})
+};
+
+exports.down = function(knex) {
+  exports.down = function(knex) {
+    return knex.schema.table('palettes', table => {
+      table.integer('project_id').unsigned()
+      table.foreign('project_id')
+      .references('projects.id');
+    })
+  };
+};

--- a/db/migrations/20200207120305_add_cascade_delete.js
+++ b/db/migrations/20200207120305_add_cascade_delete.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.integer('project_id').unsigned()
+    table.foreign('project_id')
+    .references('projects.id')
+    .onDelete('CASCADE');
+  })
+};
+exports.down = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.dropColumn('project_id');
+  });
+};


### PR DESCRIPTION
### What does this PR do?
This PR implements and tests endpoints for:
* DELETE project by id, along with all associated palettes
* GET one palette by id
* GET all palettes from the db
* POST one palette

This PR also created two new migrations:
* The first Migration is to delete the `project_id` column from the `palettes` table
* The second Migration will reinstate that column, but add `onDelete(cascade)` method

The `onDelete` allows us to bypass having to retrieve the palettes associated with a project, delete them first, then delete the project. We can target a project, delete it, and it will automatically delete the associated palettes. Pretty neat. 

### Screenshots
Current state of tests:
![D7CB974D-27E7-455D-AE16-2B7D90C7597B](https://user-images.githubusercontent.com/52764657/74061749-f65fde00-49a9-11ea-9405-645db850977c.jpeg)

### Additional Info
To get up and running, once this is merged, you'll need to run the following:
* `git pull`
* `knex migrate:latest`
* `knex migrate:latest --env=test`
* `knex seed:run`
* `knex seed:run --env=test`

### Associated Issues
* Closes #11 
* Closes #28 