### PR TITLE
Patch

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,12 +71,11 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
 
   try {
     const patchedProject = await database('projects').where('id', id).update({title: newProject.title}, ['id', 'title']);
-
     if (patchedProject.length) {
       response.status(201).json({id: patchedProject[0].id, title: patchedProject[0].title});
     } else {
       response.status(404).json({
-        error: `Could not find a project with id: ${request.params.id}`
+        error: `Could not find a project with id: ${id}`
       });
     }
   } catch (error) {
@@ -87,7 +86,6 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
 app.patch('/api/v1/palettes/:id', async (request, response) => {
   const { id } = request.params;
   const newPalette = request.body;
-  console.log(newPalette);
   try {
     const patchedPalette = await database('palettes').where('id', id)
     .update(
@@ -98,7 +96,8 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
         color_3_id: newPalette.color_3_id,
         color_4_id: newPalette.color_4_id,
         color_5_id: newPalette.color_5_id
-      }, ['id', 'title', 'color_1_id', 'color_2_id', 'color_3_id', 'color_4_id', 'color_5_id']);
+      }, ['id', 'title', 'color_1_id', 'color_2_id', 'color_3_id', 'color_4_id', 'color_5_id']
+    );
 
     if (patchedPalette.length) {
       response.status(201).json(
@@ -110,10 +109,11 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
           color_3_id: patchedPalette[0].color_3_id,
           color_4_id: patchedPalette[0].color_4_id,
           color_5_id: patchedPalette[0].color_5_id
-        });
+        }
+      );
     } else {
       response.status(404).json({
-        error: `Could not find a palette with id: ${request.params.id}`
+        error: `Could not find a palette with id: ${id}`
       });
     }
   } catch (error) {

--- a/app.js
+++ b/app.js
@@ -84,6 +84,43 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
   }
 });
 
+app.patch('/api/v1/palettes/:id', async (request, response) => {
+  const { id } = request.params;
+  const newPalette = request.body;
+  console.log(newPalette);
+  try {
+    const patchedPalette = await database('palettes').where('id', id)
+    .update(
+      {
+        title: newPalette.title,
+        color_1_id: newPalette.color_1_id,
+        color_2_id: newPalette.color_2_id,
+        color_3_id: newPalette.color_3_id,
+        color_4_id: newPalette.color_4_id,
+        color_5_id: newPalette.color_5_id
+      }, ['id', 'title', 'color_1_id', 'color_2_id', 'color_3_id', 'color_4_id', 'color_5_id']);
+
+    if (patchedPalette.length) {
+      response.status(201).json(
+        {
+          id: patchedPalette[0].id,
+          title: patchedPalette[0].title,
+          color_1_id: patchedPalette[0].color_1_id,
+          color_2_id: patchedPalette[0].color_2_id,
+          color_3_id: patchedPalette[0].color_3_id,
+          color_4_id: patchedPalette[0].color_4_id,
+          color_5_id: patchedPalette[0].color_5_id
+        });
+    } else {
+      response.status(404).json({
+        error: `Could not find a palette with id: ${request.params.id}`
+      });
+    }
+  } catch (error) {
+    response.status(500).json({error: 'internal server error' })
+  }
+});
+
 app.delete('/api/v1/palettes/:id', async (request, response) => {
   const { id } = request.params;
 

--- a/app.js
+++ b/app.js
@@ -95,8 +95,9 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
         color_2_id: newPalette.color_2_id,
         color_3_id: newPalette.color_3_id,
         color_4_id: newPalette.color_4_id,
-        color_5_id: newPalette.color_5_id
-      }, ['id', 'title', 'color_1_id', 'color_2_id', 'color_3_id', 'color_4_id', 'color_5_id']
+        color_5_id: newPalette.color_5_id,
+        project_id: newPalette.project_id
+      }, ['id', 'title', 'color_1_id', 'color_2_id', 'color_3_id', 'color_4_id', 'color_5_id', 'project_id']
     );
 
     if (patchedPalette.length) {
@@ -108,7 +109,9 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
           color_2_id: patchedPalette[0].color_2_id,
           color_3_id: patchedPalette[0].color_3_id,
           color_4_id: patchedPalette[0].color_4_id,
-          color_5_id: patchedPalette[0].color_5_id
+          color_5_id: patchedPalette[0].color_5_id,
+          project_id: patchedPalette[0].project_id
+
         }
       );
     } else {

--- a/app.test.js
+++ b/app.test.js
@@ -189,8 +189,6 @@ describe('Server', () => {
       const { id } = expectedPalette;
       const response = await request(app).get(`/api/v1/palettes/${id}`);
       const result = response.body;
-        delete result.created_at;
-        delete result.updated_at;
 
       expect(response.status).toBe(200);
       expect(result).toEqual(expectedPalette);
@@ -198,10 +196,10 @@ describe('Server', () => {
 
     it('should return a 404 if the specific palette is not found', async () => {
       const invalidId = -467;
-  
+
 
       const response = await request(app).get(`/api/v1/palettes/${invalidId}`);
-      
+
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidId}`);
     });
@@ -256,10 +254,10 @@ describe('Server', () => {
         color_3_id: '#fcd443',
         color_4_id: '#facd43',
         color_5_id: '#23f443',
-        project_id: project.id, 
+        project_id: project.id,
       };
       const response = await request(app).post('/api/v1/palettes').send(newPalette);
-  
+
       expect(response.status).toBe(422);
       expect(response.body.error).toBe(`Expected format: { title: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, color_1_id: <String>, project_id: <Integer> }. You're missing a "color_1_id" property.`)
     });

--- a/app.test.js
+++ b/app.test.js
@@ -100,14 +100,14 @@ describe('Server', () => {
       expect(revisedProject).toEqual(expectedResult);
     });
 
-    it('should return a sad 404 code if the targeted project is not found', async () => {
-      const invalidTargetId = -24;
-
-      const response = await request(app).get(`/api/v1/projects/${invalidTargetId}`);
-
-      expect(response.status).toBe(404);
-      expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
-    });
+    // it('should return a sad 404 code if the targeted project is not found', async () => {
+    //   const invalidTargetId = -24;
+    //
+    //   const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`);
+    //
+    //   expect(response.status).toBe(404);
+    //   expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
+    // });
   });
 
   describe('PATCH /api/v1/palettes/:id', () => {

--- a/app.test.js
+++ b/app.test.js
@@ -86,7 +86,6 @@ describe('Server', () => {
       const newProject = { title: 'Master bedroom' };
       const targetProject = await database('projects').first();
       const { id } = targetProject;
-      console.log(id);
 
       const response = await request(app).patch(`/api/v1/projects/${id}`).send(newProject)
 
@@ -109,6 +108,52 @@ describe('Server', () => {
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
     });
+  });
+
+  describe('PATCH /api/v1/palettes/:id', () => {
+    it('should return a happy status of 201 and update a specific palette color', async () => {
+      const targetPalette = await database('palettes').first();
+      console.log(targetPalette);
+      const { id } = targetPalette;
+
+      const newPalette =  {
+        title: targetPalette.title,
+        color_1_id: '#abcdef',
+        color_2_id: targetPalette.color_2_id,
+        color_3_id: targetPalette.color_3_id,
+        color_4_id: targetPalette.color_4_id,
+        color_5_id: targetPalette.color_5_id
+      };
+
+      const response = await request(app).patch(`/api/v1/palettes/${id}`).send(newPalette)
+
+      const revisedPaletteArray = await database('palettes').where('id', id);
+      const revisedPalette = revisedPaletteArray[0];
+        delete revisedPalette.created_at;
+        delete revisedPalette.updated_at;
+
+      const expectedResult = {
+        id,
+        title: newPalette.title,
+        color_1_id: newPalette.color_1_id,
+        color_2_id: newPalette.color_2_id,
+        color_3_id: newPalette.color_3_id,
+        color_4_id: newPalette.color_4_id,
+        color_5_id: newPalette.color_5_id
+      };
+
+      expect(response.status).toBe(201);
+      expect(revisedPalette).toEqual(expectedResult);
+    });
+
+    // it('should return a sad 404 code if the targeted project is not found', async () => {
+    //   const invalidTargetId = -24;
+    //
+    //   const response = await request(app).get(`/api/v1/projects/${invalidTargetId}`);
+    //
+    //   expect(response.status).toBe(404);
+    //   expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
+    // });
   });
 
   describe('DELETE /api/v1/palettes/:id', () => {

--- a/app.test.js
+++ b/app.test.js
@@ -121,7 +121,8 @@ describe('Server', () => {
         color_2_id: targetPalette.color_2_id,
         color_3_id: targetPalette.color_3_id,
         color_4_id: targetPalette.color_4_id,
-        color_5_id: targetPalette.color_5_id
+        color_5_id: targetPalette.color_5_id,
+        project_id: targetPalette.project_id
       };
 
       const response = await request(app).patch(`/api/v1/palettes/${id}`).send(newPalette)
@@ -130,7 +131,6 @@ describe('Server', () => {
       const revisedPalette = revisedPaletteArray[0];
         delete revisedPalette.created_at;
         delete revisedPalette.updated_at;
-        delete revisedPalette.project_id;
 
       const expectedResult = {
         id,
@@ -139,7 +139,8 @@ describe('Server', () => {
         color_2_id: newPalette.color_2_id,
         color_3_id: newPalette.color_3_id,
         color_4_id: newPalette.color_4_id,
-        color_5_id: newPalette.color_5_id
+        color_5_id: newPalette.color_5_id,
+        project_id: newPalette.project_id
       };
 
       expect(response.status).toBe(201);

--- a/app.test.js
+++ b/app.test.js
@@ -111,7 +111,7 @@ describe('Server', () => {
   });
 
   describe('PATCH /api/v1/palettes/:id', () => {
-    it('should return a happy status of 201 and update a specific palette color', async () => {
+    it('should return a happy status of 201 and update a specific palette', async () => {
       const targetPalette = await database('palettes').first();
       console.log(targetPalette);
       const { id } = targetPalette;
@@ -131,6 +131,7 @@ describe('Server', () => {
       const revisedPalette = revisedPaletteArray[0];
         delete revisedPalette.created_at;
         delete revisedPalette.updated_at;
+        delete revisedPalette.project_id;
 
       const expectedResult = {
         id,

--- a/app.test.js
+++ b/app.test.js
@@ -113,7 +113,6 @@ describe('Server', () => {
   describe('PATCH /api/v1/palettes/:id', () => {
     it('should return a happy status of 201 and update a specific palette', async () => {
       const targetPalette = await database('palettes').first();
-      console.log(targetPalette);
       const { id } = targetPalette;
 
       const newPalette =  {
@@ -147,13 +146,14 @@ describe('Server', () => {
       expect(revisedPalette).toEqual(expectedResult);
     });
 
-    // it('should return a sad 404 code if the targeted project is not found', async () => {
-    //   const invalidTargetId = -24;
-    //
-    //   const response = await request(app).get(`/api/v1/projects/${invalidTargetId}`);
+    // it('should return a sad 404 code if the targeted palette is not found', async () => {
+    //   const invalidTargetId = -675324;
+    //   const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`);
     //
     //   expect(response.status).toBe(404);
-    //   expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
+    //   console.log(response.body);
+    //   //The response body is returning an empty object (so body.error = undef)
+    //   expect(response.body).toEqual(`Could not find a palette with id: ${invalidTargetId}`);
     // });
   });
 

--- a/app.test.js
+++ b/app.test.js
@@ -101,14 +101,14 @@ describe('Server', () => {
       expect(revisedProject).toEqual(expectedResult);
     });
 
-    // it('should return a sad 404 code if the targeted project is not found', async () => {
-    //   const invalidTargetId = -24;
-    //
-    //   const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`);
-    //
-    //   expect(response.status).toBe(404);
-    //   expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
-    // });
+    it('should return a sad 404 code if the targeted project is not found', async () => {
+      const invalidTargetId = -24;
+
+      const response = await request(app).get(`/api/v1/projects/${invalidTargetId}`).send(`${invalidTargetId}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find a project with id: ${invalidTargetId}`);
+    });
   });
 
   describe('PATCH /api/v1/palettes/:id', () => {
@@ -148,15 +148,15 @@ describe('Server', () => {
       expect(revisedPalette).toEqual(expectedResult);
     });
 
-    // it('should return a sad 404 code if the targeted palette is not found', async () => {
-    //   const invalidTargetId = -675324;
-    //   const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`);
-    //
-    //   expect(response.status).toBe(404);
-    //   console.log(response.body);
-    //   //The response body is returning an empty object (so body.error = undef)
-    //   expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidTargetId}`);
-    // });
+    it('should return a sad 404 code if the targeted palette is not found', async () => {
+      const invalidTargetId = -675324;
+      const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`).send(`${invalidTargetId}`);
+
+      expect(response.status).toBe(404);
+      console.log(response.body);
+      //The response body is returning an empty object (so body.error = undef)
+      expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidTargetId}`);
+    });
   });
 
   describe('DELETE /api/v1/palettes/:id', () => {

--- a/app.test.js
+++ b/app.test.js
@@ -153,7 +153,7 @@ describe('Server', () => {
     //   expect(response.status).toBe(404);
     //   console.log(response.body);
     //   //The response body is returning an empty object (so body.error = undef)
-    //   expect(response.body).toEqual(`Could not find a palette with id: ${invalidTargetId}`);
+    //   expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidTargetId}`);
     // });
   });
 


### PR DESCRIPTION
### What's this PR do?
- Integrates the edits from the last PR (Endpoints - Dustin)
- Adds the second PATCH endpoint (for editing a palette)
- Adds the happy path test for said PATCH
- Adds commented out code for the FAILING sad path test for said PATCH
- Revises the previous sad test for the first Patch, and also comments that out

### Any background information?
- The PATCH for altering a single color in a palette serves to alter from one of to all of the palette properties if need be
- Our combined endpoints in app.js and the corresponding tests in app.test.js could be polished by clustering all of the endpoint types together. I didn't group them because it makes the PR file changes a little overwhelming with so much relocating of code blocks. I'll open an issue and we can treat it a low-priority chore.
- I haven't able to solve the mystery of the failing sad path tests for the PATCH requests. Despite having nearly identical code to other sad tests, it's not working. The response.status does indeed return a 404 when the database is presented with a query for a non-existent ID value, but the response.body comes back as an empty object { } with no error property to display the error string from the implementation code.

```
    it('should return a sad 404 code if the targeted palette is not found', async () => {
      const invalidTargetId = -675324;
      const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`);
    
      expect(response.status).toBe(404);
      console.log(response.body);

      //The response body is returning an empty object (so response.body.error = undefined)

      expect(response.body.error).toEqual(`Could not find a palette with id: ${invalidTargetId}`);
    });
```

I've tried both
```
const response = await request(app).get(`/api/v1/palettes/${invalidTargetId}`);
```
And
```
const response = await request(app).patch(`/api/v1/palettes/${invalidTargetId}`);
```

**POSSIBLE SOLUTIONS:**
- Instead of testing **response.body.error**, we can maybe look at a separate property on the massive response object for testing.
- We could perhaps manipulate the the .json() clause in the implementation code to somehow populate the response object with a body that isn't an empty object
- We could expect only the failed 404 status, without the need for a clarifying error string

### Where should the reviewer start?
- Please try to troubleshoot the commented out tests

### Pertinent Issues
- Partially addresses #18 
- Resolves #7 

### Screenshots
-n/a