### PR TITLE
Add in query params on GET all palettes

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,20 +169,40 @@ app.get('/api/v1/palettes/:id', async (request, response ) => {
 });
 
 app.get('/api/v1/palettes', async (request, response) => {
-  try {
-    const palettes = await database('palettes').select();
-    const displayPalettes = palettes.map(palette => ({
-      id: palette.id,
-      title: palette.title,
-      color_1_id: palette.color_1_id,
-      color_2_id: palette.color_2_id,
-      color_3_id: palette.color_3_id,
-      color_4_id: palette.color_4_id,
-      color_5_id: palette.color_5_id,
-      project_id: palette.project_id
-    }));
+  let queryCode = await request.query.hexCode;
+  let hexCode = `#${queryCode}`;
 
-    response.status(200).json({ palettes: displayPalettes });
+  try {
+    if (queryCode) {
+      const queryPalettes = await database('palettes').where('color_1_id', hexCode).orWhere('color_2_id', hexCode).orWhere('color_3_id', hexCode).orWhere('color_4_id', hexCode).orWhere('color_5_id', hexCode);
+
+      const displayPalettes = queryPalettes.map(palette => ({
+        id: palette.id,
+        title: palette.title,
+        color_1_id: palette.color_1_id,
+        color_2_id: palette.color_2_id,
+        color_3_id: palette.color_3_id,
+        color_4_id: palette.color_4_id,
+        color_5_id: palette.color_5_id,
+        project_id: palette.project_id
+      }));
+
+      response.status(200).json({ palettes: displayPalettes });
+    } else {
+      const palettes = await database('palettes').select();
+      const displayPalettes = palettes.map(palette => ({
+        id: palette.id,
+        title: palette.title,
+        color_1_id: palette.color_1_id,
+        color_2_id: palette.color_2_id,
+        color_3_id: palette.color_3_id,
+        color_4_id: palette.color_4_id,
+        color_5_id: palette.color_5_id,
+        project_id: palette.project_id
+      }));
+
+      response.status(200).json({ palettes: displayPalettes });
+    } 
   } catch (error) {
     response.status(500).json({ error });
   }
@@ -230,7 +250,6 @@ app.delete('/api/v1/projects/:id', async (request, response) => {
   } catch (error) {
     response.status(500).json({ error });
   }
-})
-
+});
 
 module.exports = app;

--- a/projects.js
+++ b/projects.js
@@ -35,7 +35,7 @@ const projects = [
         title: "counter",
         color_1_id: "#bb211b",
         color_2_id: "#220311",
-        color_3_id: "#ab3300",
+        color_3_id: "#bbbbbb",
         color_4_id: "#55hd97",
         color_5_id: "#929911"
       }


### PR DESCRIPTION
### What does this PR do?
This PR modifies the `GET /api/v1/palettes` endpoint to look for query params and return a modified array if the request offers any.

### Where should the reviewer start?
In `app.js`, you'll see the added code in the `/api/v1/palettes` endpoint starting on line 172. There is added code to extract any query params and format them to match the database format. 

### Background info?
At first I was going to make an entirely new endpoint like `/api/v1/palettes?hexCode=:hexCode`, but that wasn't working. So I did some research, and when a `?` is thrown into a URL, that denotes that there are query params being passed in as `key: value` pairs, where `?hexCode=bbbbbb` results in `{hexCode: 'bbbbbb'`. We can then query our database as normal with the `where` syntax, with the added in `.orWhere` method that basically allows you to `find all palettes where color 1 equals hexcode value, OR  color 2 equals hexCode value, etc, etc`. 